### PR TITLE
Fix timezone issue

### DIFF
--- a/site_generator.py
+++ b/site_generator.py
@@ -6,7 +6,7 @@ import shutil
 import textwrap
 
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 def slugify(title):
     """
@@ -207,8 +207,9 @@ def generate_html(db_name="movie_showtimes.db",
     for date in showtimes_by_date:
         showtimes_by_date[date].sort(key=lambda x: parse_time_from_formatted_datetime(x.get("formatted_datetime", "")))
     
-    # Get today's date (only the date part)
-    today = datetime.today().date()
+    # Get today's date (only the date part). EST vs EDT should be close enough.
+    tz = timezone(timedelta(hours=-4))
+    today = datetime.now(tz).date()
     
     # Create a sorted list of dates (as strings) that are today or in the future.
     # Use formatted datetime to determine if date is in future


### PR DESCRIPTION
The server was running on UTC, meaning that datetime.now() was returning the following day if the time was after 7 or 8pm (depending on DST). Since we only show events starting today onward, this meant that in the evening you'd stop seeing the same day's movies. Fix that by using (an approximation to) the actual EST timezone.

This is somewhat speculative as I'm just testing locally but I think it makes sense (I did verify that running the code on the server via ssh gave the correct time, at least).